### PR TITLE
Updated README instructions to use --save-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ nicely readable, like so:
 
 ![Screenshot](http://labs.toolness.com/tap-prettify-2.png)
 
-To use it, simply `npm install tap-prettify` and then use the
+To use it, simply `npm install --save-dev tap-prettify` and then use the
 `tap-prettify` executable instead of `tap` to run your tests.
 
 Here's the help documentation for `tap-prettify`:


### PR DESCRIPTION
This is a dev-only tool, and should therefore only be included in `devDependencies`.  If included in the non-dev bundle, it would needlessly increase the size and potentially expose security issues now or in the future.